### PR TITLE
Integrating Distributions.jl to output loglikelihood cost function

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -8,3 +8,4 @@ Calculus
 Optim
 Compat 0.17.0
 PenaltyFunctions
+Distributions

--- a/src/build_loss_objective.jl
+++ b/src/build_loss_objective.jl
@@ -17,7 +17,7 @@ function build_loss_objective(prob::DEProblem,alg,loss,regularization=nothing;mp
   end
   cost_function = function (p)
     tmp_prob = prob_generator(prob,p)
-    if typeof(loss) <: Union{CostVData,L2Loss}
+    if typeof(loss) <: Union{CostVData,L2Loss,LogLikelihood}
       sol = solve(tmp_prob,alg;saveat=loss.t,save_everystep=false,dense=false,kwargs...)
     else
       sol = solve(tmp_prob,alg;kwargs...)


### PR DESCRIPTION
This PR demonstrates how to integrate Distributions.jl to find log likelihood cost function by taking a case when all the observations independently follow Normal Distribution. 
This would act as the guideline to integrate other cases as the need arise.