### PR TITLE
Fix autodiff setup

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -6,5 +6,4 @@ RecursiveArrayTools 0.10.0
 ForwardDiff
 Calculus
 Optim
-Compat 0.17.0
 PenaltyFunctions

--- a/src/DiffEqParamEstim.jl
+++ b/src/DiffEqParamEstim.jl
@@ -3,8 +3,6 @@ __precompile__()
 module DiffEqParamEstim
 using DiffEqBase, LsqFit, LossFunctions, PenaltyFunctions, RecursiveArrayTools, ForwardDiff, Calculus
 
-using Compat
-
 include("cost_functions.jl")
 include("lm_fit.jl")
 include("build_loss_objective.jl")

--- a/src/build_loss_objective.jl
+++ b/src/build_loss_objective.jl
@@ -40,7 +40,7 @@ function build_loss_objective(prob::DEProblem,alg,loss,regularization=nothing;mp
   end
 
   if mpg_autodiff
-    gcfg = ForwardDiff.GradientConfig(zeros(num_params(prob)))
+    gcfg = ForwardDiff.GradientConfig(cost_function, zeros(num_params(prob)))
     g! = (x, out) -> ForwardDiff.gradient!(out, cost_function, x, gcfg)
   else
     g! = (x, out) -> Calculus.finite_difference!(cost_function,x,out,:central)

--- a/src/build_loss_objective.jl
+++ b/src/build_loss_objective.jl
@@ -11,6 +11,8 @@ end
 function build_loss_objective(prob::DEProblem,alg,loss,regularization=nothing;mpg_autodiff = false,
                               verbose_opt = false,verbose_steps = 100,
                               prob_generator = problem_new_parameters,
+                              autodiff_prototype = mpg_autodiff ? zeros(num_params(prob)) : nothing,
+                              autodiff_chunk = mpg_autodiff ? ForwardDiff.Chunk(autodiff_prototype) : nothing,
                               kwargs...)
   if verbose_opt
     count = 0 # keep track of # function evaluations
@@ -40,7 +42,7 @@ function build_loss_objective(prob::DEProblem,alg,loss,regularization=nothing;mp
   end
 
   if mpg_autodiff
-    gcfg = ForwardDiff.GradientConfig(cost_function, zeros(num_params(prob)))
+    gcfg = ForwardDiff.GradientConfig(cost_function, autodiff_prototype, autodiff_chunk)
     g! = (x, out) -> ForwardDiff.gradient!(out, cost_function, x, gcfg)
   else
     g! = (x, out) -> Calculus.finite_difference!(cost_function,x,out,:central)

--- a/test/tests_on_odes/nlopt_test.jl
+++ b/test/tests_on_odes/nlopt_test.jl
@@ -26,3 +26,16 @@ xtol_rel!(opt,1e-3)
 maxeval!(opt, 100000)
 (minf,minx,ret) = NLopt.optimize(opt,[1.2])
 @test minx[1] ≈ 1.5 atol=1e-1
+
+# test differentiation
+for autodiff in (false, true)
+   obj = build_loss_objective(prob1, Tsit5(), CostVData(t,data);
+                              mpg_autodiff = autodiff, maxiters = 10000)
+
+   opt = Opt(:LD_MMA, 1)
+   min_objective!(opt, obj.cost_function2)
+   xtol_rel!(opt,1e-3)
+   maxeval!(opt, 10000)
+   (minf,minx,ret) = NLopt.optimize(opt, [1.3])
+   @test minx[1] ≈ 1.5 atol=1e-3
+end

--- a/test/tests_on_odes/two_stage_method_test.jl
+++ b/test/tests_on_odes/two_stage_method_test.jl
@@ -10,3 +10,18 @@ result = Optim.optimize(cost_function, [1.0,2.5], Optim.BFGS())
 cost_function = two_stage_method(prob3,t,data)
 result = Optim.optimize(cost_function, [1.3,0.8,2.8,1.2], Optim.BFGS())
 @test result.minimizer ≈ [1.5;1.0;3.0;1.0] atol=5e-1
+
+# test differentiation
+for autodiff in (false, true)
+  obj = two_stage_method(prob2,t,data; mpg_autodiff = autodiff)
+  opt = Opt(:LD_LBFGS, 2)
+  min_objective!(opt, obj.cost_function2)
+  (minf,minx,ret) = NLopt.optimize(opt, [1.0,2.5])
+  @test minx ≈ [1.5;3.0] atol=3e-1
+
+  obj = two_stage_method(prob3,t,data; mpg_autodiff = autodiff)
+  opt = Opt(:LD_LBFGS, 4)
+  min_objective!(opt, obj.cost_function2)
+  (minf,minx,ret) = NLopt.optimize(opt, [1.3,0.8,2.8,1.2])
+  @test minx ≈ [1.5;1.0;3.0;1.0] atol=5e-1
+end


### PR DESCRIPTION
Cost function was missing in the constructor of a `GradientConfig`. Moreover, I was wondering whether it might be reasonable to allow other initial vectors (for the autodifferentiation setup; currently it always creates a `Vector{Float64}`) and also custom chunk sizes, maybe as keyword arguments?

And regarding differentiation: I'm not up to date since I'm quite busy at the moment - but didn't you want to get rid of Calculus dependencies? Just noticed that the finite differentiation alternative still uses it here.