### PR TITLE
Check default two-stage kernel

### DIFF
--- a/src/two_stage_method.jl
+++ b/src/two_stage_method.jl
@@ -70,7 +70,7 @@ function construct_estimated_solution_and_derivative!(estimated_solution,estimat
   end
 end
 
-function two_stage_method(prob::DiffEqBase.DEProblem,tpoints,data;kernel= :Epanechnikov,
+function two_stage_method(prob::DiffEqBase.DEProblem,tpoints,data;kernel= :Logistic,
                           loss_func = L2Loss,mpg_autodiff = false,
                           verbose = false,verbose_steps = 100,
                           autodiff_prototype = mpg_autodiff ? zeros(length(prob.p)) : nothing,


### PR DESCRIPTION
Fixes https://github.com/JuliaDiffEq/DiffEqParamEstim.jl/issues/108 . @atrophiedbrain is there any reason to prefer the other kernels you can find? I think the default was chosen almost at random, so if this fixes some issues then we might as well go forward with it.