### PR TITLE
Fix SciMLBase v3 breaking changes and bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DiffEqParamEstim"
 uuid = "1130ab10-4a5a-5621-a13d-e4788d82bd4c"
-version = "2.3.0"
+version = "2.4.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]
@@ -27,7 +27,7 @@ ForwardDiff = "0.10"
 PenaltyFunctions = "0.1, 0.2, 0.3"
 PreallocationTools = "0.2, 0.3, 0.4, 1.0"
 RecursiveArrayTools = "1.0, 2.0, 3, 4"
-SciMLBase = "1.69, 2"
+SciMLBase = "2, 3"
 SciMLSensitivity = "7"
 Statistics = "1.10"
 StatsAPI = "1.8.0"

--- a/src/cost_functions.jl
+++ b/src/cost_functions.jl
@@ -81,7 +81,7 @@ function (f::L2Loss)(sol::SciMLBase.AbstractSciMLSolution)
     sumsq = 0.0
 
     if weight === nothing
-        @inbounds for i in 1:length(sol)
+        @inbounds for i in 1:length(sol.t)
             for j in 1:length(sol[i])
                 sumsq += (data[j, i] - sol[j, i])^2
             end
@@ -108,7 +108,7 @@ function (f::L2Loss)(sol::SciMLBase.AbstractSciMLSolution)
             end
         end
     else
-        @inbounds for i in 1:length(sol)
+        @inbounds for i in 1:length(sol.t)
             if weight isa Real
                 for j in 1:length(sol[i])
                     sumsq = sumsq + ((data[j, i] - sol[j, i])^2) * weight

--- a/src/multiple_shooting_objective.jl
+++ b/src/multiple_shooting_objective.jl
@@ -22,7 +22,7 @@ struct Merged_Solution{T1, T2, T3}
 end
 
 function multiple_shooting_objective(
-        prob::DiffEqBase.DEProblem, alg, loss,
+        prob::DiffEqBase.AbstractDEProblem, alg, loss,
         adtype = SciMLBase.NoAD(),
         regularization = nothing; priors = nothing,
         discontinuity_weight = 1.0,
@@ -72,11 +72,11 @@ function multiple_shooting_objective(
         for k in 2:K
             if discontinuity_weight isa Real
                 loss_val += discontinuity_weight *
-                    sum((sol[k][1] - sol[k - 1][end]) .^ 2)
+                    sum((sol[k].u[1] - sol[k - 1].u[end]) .^ 2)
             else
                 loss_val += sum(
                     discontinuity_weight .*
-                        (sol[k][1] - sol[k - 1][end]) .^ 2
+                        (sol[k].u[1] - sol[k - 1].u[end]) .^ 2
                 )
             end
         end

--- a/src/two_stage_method.jl
+++ b/src/two_stage_method.jl
@@ -98,7 +98,7 @@ function construct_oop_cost_function(f, du, preview_est_sol, preview_est_deriv, 
 end
 
 function two_stage_objective(
-        prob::DiffEqBase.DEProblem, tpoints, data,
+        prob::DiffEqBase.AbstractDEProblem, tpoints, data,
         adtype = SciMLBase.NoAD();
         kernel = EpanechnikovKernel()
     )


### PR DESCRIPTION
## Summary
- Replace removed `DiffEqBase.DEProblem` with `DiffEqBase.AbstractDEProblem` in `two_stage_objective` and `multiple_shooting_objective` signatures
- Fix `length(sol)` → `length(sol.t)` in `L2Loss` `AbstractSciMLSolution` dispatch (in SciMLBase v3, `length(sol)` returns `nstates * ntimesteps` rather than just `ntimesteps`)
- Fix `sol[k][1]` → `sol[k].u[1]` and `sol[k-1][end]` → `sol[k-1].u[end]` in `multiple_shooting_objective` discontinuity penalty (in v3, scalar indexing on an `ODESolution` gives the first element across all components, not the first timestep state vector)
- Update SciMLBase compat bounds: `"1.69, 2"` → `"2, 3"` (dropping v1 since the fixes are not backward compatible with v1 behavior)
- Bump package version: 2.3.0 → 2.4.0
- Supersedes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)