### PR TITLE
Migrate to SciMLBase v3 / RecursiveArrayTools v4 / DiffEqBase v7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DiffEqParamEstim"
 uuid = "1130ab10-4a5a-5621-a13d-e4788d82bd4c"
-version = "2.4.0"
+version = "2.5.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]
@@ -21,13 +21,13 @@ StatsAPI = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 Calculus = "0.5"
 CommonSolve = "0.2.6"
 Dierckx = "0.4, 0.5"
-DiffEqBase = "6"
+DiffEqBase = "6, 7"
 Distributions = "0.25"
 ForwardDiff = "0.10"
 PenaltyFunctions = "0.1, 0.2, 0.3"
 PreallocationTools = "0.2, 0.3, 0.4, 1.0"
 RecursiveArrayTools = "1.0, 2.0, 3, 4"
-SciMLBase = "1.69, 2, 3.1"
+SciMLBase = "1.69, 2, 3"
 SciMLSensitivity = "7"
 Statistics = "1.10"
 StatsAPI = "1.8.0"

--- a/src/cost_functions.jl
+++ b/src/cost_functions.jl
@@ -48,16 +48,20 @@ function (f::L2Loss)(sol::DiffEqBase.AbstractNoTimeSolution)
 
     sumsq = 0.0
 
+    # `sol.u` is the final-state vector for a NoTimeSolution (steady-state /
+    # nonlinear). Iterating `sol.u` is the forward-compatible form under both
+    # RAT v3 and v4.
+    solu = sol.u
     if weight === nothing
-        @inbounds for i in 1:length(sol)
-            sumsq += (data[i] - sol[i])^2
+        @inbounds for i in 1:length(solu)
+            sumsq += (data[i] - solu[i])^2
         end
     else
-        @inbounds for i in 1:length(sol)
+        @inbounds for i in 1:length(solu)
             if weight isa Real
-                sumsq = sumsq + ((data[i] - sol[i])^2) * weight
+                sumsq = sumsq + ((data[i] - solu[i])^2) * weight
             else
-                sumsq = sumsq + ((data[i] - sol[i])^2) * weight[i]
+                sumsq = sumsq + ((data[i] - solu[i])^2) * weight[i]
             end
         end
     end
@@ -80,8 +84,13 @@ function (f::L2Loss)(sol::SciMLBase.AbstractSciMLSolution)
 
     sumsq = 0.0
 
+    # Under RAT v4, `AbstractVectorOfArray <: AbstractArray`, so `length(sol)`
+    # is the total scalar element count, not the number of timesteps. Iterate
+    # `sol.u` explicitly for the forward-compatible form. 2-argument indexing
+    # `sol[j, i]` keeps the same (component, time) meaning under both v3 and v4.
+    nsteps = length(sol.u)
     if weight === nothing
-        @inbounds for i in 1:length(sol)
+        @inbounds for i in 1:nsteps
             for j in 1:length(sol.u[i])
                 sumsq += (data[j, i] - sol[j, i])^2
             end
@@ -108,7 +117,7 @@ function (f::L2Loss)(sol::SciMLBase.AbstractSciMLSolution)
             end
         end
     else
-        @inbounds for i in 1:length(sol)
+        @inbounds for i in 1:nsteps
             if weight isa Real
                 for j in 1:length(sol.u[i])
                     sumsq = sumsq + ((data[j, i] - sol[j, i])^2) * weight
@@ -195,7 +204,8 @@ end
 function (f::LogLikeLoss)(sol::SciMLBase.AbstractSciMLSolution)
     distributions = f.data_distributions
     if sol isa DiffEqBase.AbstractEnsembleSolution
-        failure = any(!SciMLBase.successful_retcode(s.retcode) for s in sol)
+        # `sol.u` is the vector of trajectories under both RAT v3 and v4.
+        failure = any(!SciMLBase.successful_retcode(s.retcode) for s in sol.u)
     else
         failure = !SciMLBase.successful_retcode(sol.retcode)
     end
@@ -244,7 +254,10 @@ end
 
 function (f::LogLikeLoss)(sol::DiffEqBase.AbstractEnsembleSolution)
     distributions = f.data_distributions
-    failure = any(!SciMLBase.successful_retcode(s.retcode) for s in sol)
+    # Under RAT v4, `AbstractEnsembleSolution <: AbstractArray` and iterating
+    # `sol` yields scalar elements, not trajectories. Iterate `sol.u` for
+    # trajectory-wise access in a way that is forward-compatible with v3/v4.
+    failure = any(!SciMLBase.successful_retcode(s.retcode) for s in sol.u)
     failure && return Inf
     ll = 0.0
     if eltype(distributions) <: UnivariateDistribution
@@ -252,7 +265,7 @@ function (f::LogLikeLoss)(sol::DiffEqBase.AbstractEnsembleSolution)
             # i is the number of time points
             # j is the size of the system
             # corresponds to distributions[i,j]
-            vals = [s[i, j] for s in sol]
+            vals = [s[i, j] for s in sol.u]
             ll -= loglikelihood(distributions[i, j], vals)
         end
     else
@@ -260,7 +273,7 @@ function (f::LogLikeLoss)(sol::DiffEqBase.AbstractEnsembleSolution)
             # i is the number of time points
             # j is the size of the system
             # corresponds to distributions[i,j]
-            vals = [s[i, j] for i in 1:length(sol.u[1].u[1]), s in sol]
+            vals = [s[i, j] for i in 1:length(sol.u[1].u[1]), s in sol.u]
             ll -= loglikelihood(distributions[j], vals)
         end
     end
@@ -271,12 +284,12 @@ function (f::LogLikeLoss)(sol::DiffEqBase.AbstractEnsembleSolution)
         if eltype(distributions) <: UnivariateDistribution
             for j in 2:length(f.t), i in 1:length(sol.u[1].u[1])
 
-                vals = [s[i, j] - s[i, j - 1] for s in sol]
+                vals = [s[i, j] - s[i, j - 1] for s in sol.u]
                 fdll -= logpdf(distributions[j - 1, i], vals)[1]
             end
         else
             for j in 2:length(f.t)
-                vals = [s[i, j] - s[i, j - 1] for i in 1:length(sol.u[1].u[1]), s in sol]
+                vals = [s[i, j] - s[i, j - 1] for i in 1:length(sol.u[1].u[1]), s in sol.u]
                 fdll -= logpdf(distributions[j - 1], vals)[1]
             end
         end

--- a/src/cost_functions.jl
+++ b/src/cost_functions.jl
@@ -40,7 +40,6 @@ function (f::L2Loss)(sol::DiffEqBase.AbstractNoTimeSolution)
     dudt = f.dudt
 
     if sol isa DiffEqBase.AbstractEnsembleSolution
-        # `sol.u` is the vector of trajectories under both RAT v3 and v4.
         failure = any(!SciMLBase.successful_retcode(s.retcode) for s in sol.u)
     else
         failure = !SciMLBase.successful_retcode(sol.retcode)
@@ -49,9 +48,6 @@ function (f::L2Loss)(sol::DiffEqBase.AbstractNoTimeSolution)
 
     sumsq = 0.0
 
-    # `sol.u` is the final-state vector for a NoTimeSolution (steady-state /
-    # nonlinear). Iterating `sol.u` is the forward-compatible form under both
-    # RAT v3 and v4.
     solu = sol.u
     if weight === nothing
         @inbounds for i in 1:length(solu)
@@ -77,7 +73,6 @@ function (f::L2Loss)(sol::SciMLBase.AbstractSciMLSolution)
     dudt = f.dudt
 
     if sol isa DiffEqBase.AbstractEnsembleSolution
-        # `sol.u` is the vector of trajectories under both RAT v3 and v4.
         failure = any(!SciMLBase.successful_retcode(s.retcode) for s in sol.u)
     else
         failure = !SciMLBase.successful_retcode(sol.retcode)
@@ -86,10 +81,6 @@ function (f::L2Loss)(sol::SciMLBase.AbstractSciMLSolution)
 
     sumsq = 0.0
 
-    # Under RAT v4, `AbstractVectorOfArray <: AbstractArray`, so `length(sol)`
-    # is the total scalar element count, not the number of timesteps. Iterate
-    # `sol.u` explicitly for the forward-compatible form. 2-argument indexing
-    # `sol[j, i]` keeps the same (component, time) meaning under both v3 and v4.
     nsteps = length(sol.u)
     if weight === nothing
         @inbounds for i in 1:nsteps
@@ -206,7 +197,6 @@ end
 function (f::LogLikeLoss)(sol::SciMLBase.AbstractSciMLSolution)
     distributions = f.data_distributions
     if sol isa DiffEqBase.AbstractEnsembleSolution
-        # `sol.u` is the vector of trajectories under both RAT v3 and v4.
         failure = any(!SciMLBase.successful_retcode(s.retcode) for s in sol.u)
     else
         failure = !SciMLBase.successful_retcode(sol.retcode)
@@ -256,9 +246,6 @@ end
 
 function (f::LogLikeLoss)(sol::DiffEqBase.AbstractEnsembleSolution)
     distributions = f.data_distributions
-    # Under RAT v4, `AbstractEnsembleSolution <: AbstractArray` and iterating
-    # `sol` yields scalar elements, not trajectories. Iterate `sol.u` for
-    # trajectory-wise access in a way that is forward-compatible with v3/v4.
     failure = any(!SciMLBase.successful_retcode(s.retcode) for s in sol.u)
     failure && return Inf
     ll = 0.0

--- a/src/cost_functions.jl
+++ b/src/cost_functions.jl
@@ -40,7 +40,8 @@ function (f::L2Loss)(sol::DiffEqBase.AbstractNoTimeSolution)
     dudt = f.dudt
 
     if sol isa DiffEqBase.AbstractEnsembleSolution
-        failure = any(!SciMLBase.successful_retcode(s.retcode) for s in sol)
+        # `sol.u` is the vector of trajectories under both RAT v3 and v4.
+        failure = any(!SciMLBase.successful_retcode(s.retcode) for s in sol.u)
     else
         failure = !SciMLBase.successful_retcode(sol.retcode)
     end
@@ -76,7 +77,8 @@ function (f::L2Loss)(sol::SciMLBase.AbstractSciMLSolution)
     dudt = f.dudt
 
     if sol isa DiffEqBase.AbstractEnsembleSolution
-        failure = any(!SciMLBase.successful_retcode(s.retcode) for s in sol)
+        # `sol.u` is the vector of trajectories under both RAT v3 and v4.
+        failure = any(!SciMLBase.successful_retcode(s.retcode) for s in sol.u)
     else
         failure = !SciMLBase.successful_retcode(sol.retcode)
     end

--- a/test/tests_on_odes/regularization_test.jl
+++ b/test/tests_on_odes/regularization_test.jl
@@ -36,8 +36,8 @@ result = solve(optprob, Optim.BFGS())
 
 optprob = Optimization.OptimizationProblem(cost_function_2, [1.2, 2.7])
 result = solve(optprob, Optim.BFGS())
-@test result.minimizer ≈ [1.5; 3.0] atol = 3.0e-1
+@test result.u ≈ [1.5; 3.0] atol = 3.0e-1
 
 optprob = Optimization.OptimizationProblem(cost_function_3, [1.3, 0.8, 2.8, 1.2])
 result = solve(optprob, Optim.BFGS())
-@test result.minimizer ≈ [1.5; 1.0; 3.0; 1.0] atol = 5.0e-1
+@test result.u ≈ [1.5; 1.0; 3.0; 1.0] atol = 5.0e-1


### PR DESCRIPTION
## Summary

This PR supersedes and extends #292 (Dependabot), which only widened the
`DiffEqBase` compat bound in `Project.toml` without the accompanying code
migration. Running with DiffEqBase v7 actually pulls in `SciMLBase v3` and
`RecursiveArrayTools v4`, both of which have code-level breaking changes that
affect this package.

Changes grouped by breaking-change category, per the OrdinaryDiffEq v7
`NEWS.md` migration guide:

### RecursiveArrayTools v4 — `AbstractVectorOfArray <: AbstractArray`

This is the largest source of actual breakage for a loss-function package.

- **`length(sol)` semantics changed.** Under RAT v4, `length(sol)` is the
  total scalar element count (`prod(size(sol))`), not the number of
  timesteps. Replaced the four timestep-counting loops in
  `L2Loss(::AbstractSciMLSolution)` and the final-state iteration in
  `L2Loss(::AbstractNoTimeSolution)` to compute `length(sol.u)` once and
  iterate `1:nsteps`, matching the previous behavior on both RAT v3 and v4.
- **Iterating an `AbstractEnsembleSolution` yields scalar elements, not
  trajectories.** Fixed four call sites in `LogLikeLoss` and two call sites
  in `L2Loss` that did `for s in sol` / `[s[i, j] for s in sol]`, switching
  them to `sol.u`. This is the forward-compatible form that works under both
  v3 and v4.

2-argument `sol[j, i]` (component `j` at time `i`) is unchanged — it resolves
to `sol.u[i][j]` under both v3 and v4, so the inner loop bodies in
`L2Loss` and `LogLikeLoss` do not need to change.

### SciMLBase v3 — `OptimizationSolution.minimizer` removed

`sol.minimizer` / `sol.minimum` on an `AbstractOptimizationSolution` are
removed in SciMLBase v3; replacements are `sol.u` / `sol.objective`. Updated
two `@test result.minimizer ≈ …` checks in
`test/tests_on_odes/regularization_test.jl` to use `result.u`. The other
`result.minimizer` call sites in the test suite come from
`Optim.optimize(...)` (returning `Optim.OptimizationResults`, which keeps
`.minimizer`) and are unaffected.

### Audited-but-unaffected categories

For completeness, the following categories from the v7 migration guide were
checked and **do not** affect this package:

- `sol.destats` / `has_destats` — zero hits in `src/` or `test/`.
- `DEAlgorithm` / `DEProblem` / `DESolution` abstract-type renames — zero
  hits. (`SciMLBase.AbstractDEProblem` is a different, still-exported name
  and is unchanged.)
- `u_modified!` / `integrator.u_modified` → `derivative_discontinuity!` —
  zero hits.
- `symbol_to_ReturnCode`, `tuples()`, `intervals()`, `IntegratorTuples`,
  `QuadratureProblem`, `IntegralProblem` `nout`/`batch`, `prob.lb`/`prob.ub`
  — zero hits.
- `concrete_solve`, `fastpow`, `RECOMPILE_BY_DEFAULT`, `DEStats` — zero hits.
- Ensemble `prob_func(prob, i, repeat)` → `prob_func(prob, ctx)` — the only
  ensemble handling in the package (`STANDARD_PROB_GENERATOR` for
  `EnsembleProblem` in `src/DiffEqParamEstim.jl`) just forwards the user's
  `prob_func` and never calls it, so no signature update is required here.
- Algorithm struct `{CS, AD, FDT, ST, CJ}` type parameters, `chunk_size` /
  `diff_type` / `standardtag` / `precs` kwargs, controller kwargs
  (`gamma`/`beta1`/`beta2`/`qmin`/`qmax`/...), `integrator.EEst` — none are
  referenced in `src/` or `test/` (DiffEqParamEstim never constructs
  solvers directly; it takes `alg` as an argument and forwards it).
- `Bool` → typed-object kwargs (`autodiff`, `verbose`, `alias`, `lazy`) —
  the only user-visible site is `verbose = false/true` in test files, which
  is forwarded to the ODE `solve` inside `build_loss_objective`. Left
  unchanged — the underlying `solve` still accepts `Bool` for `verbose` in
  the v6-compatible path that CI actually resolves against (see below).
- `construct*` tableau functions, `Euler`/`KenCarp`/etc. solver exports — no
  non-default solvers are referenced in the `runtests.jl`-included test
  files. (`lorenz_test.jl` and `lorenz_true_test.jl` use `Euler()` but are
  not included in `runtests.jl`.)

### `Project.toml`

- `DiffEqBase` compat widened from `6` to `"6, 7"` (matches #292's intent).
- `SciMLBase` compat widened from `"1.69, 2, 3.1"` to `"1.69, 2, 3"` (the
  `3.1` lower bound was too tight — SciMLBase v3.0 already has the breaking
  changes we now handle).
- `RecursiveArrayTools` already had `"1.0, 2.0, 3, 4"`, left as-is.
- Version bump to `2.5.0`.

## Ecosystem note — resolution state as of this PR

At the time of this PR, `OrdinaryDiffEq` on the General registry is still
`v6.111.0`, which pins `DiffEqBase = 6` / `SciMLBase = 2` / `RAT = 3`.
So a fresh CI resolve with the widened compat in this PR still selects:

- DiffEqBase = 6.x
- SciMLBase = 2.x
- RecursiveArrayTools = 3.x

CI therefore exercises the **RAT v3 path** of the code. The code in this PR
is written to be source-compatible with both RAT v3 and v4 — the migration
shortcuts from the `NEWS.md` guide are all forward-compatible
(`sol.u[i]` / `for s in sol.u` / `length(sol.u)` work identically on v3),
so once `OrdinaryDiffEq v7` is released and the resolver begins picking
`DiffEqBase = 7`, this package will just work without further changes.

## Test plan

- [x] Audit every category from `OrdinaryDiffEq.jl` `NEWS.md` v7 migration
      guide against `src/` and `test/`.
- [x] `using DiffEqParamEstim` loads under both the v6 (CI) and v7 (local
      dev) resolutions.
- [x] Manual verification on RAT v4: `VectorOfArray([[1,2],[3,4],[5,6]])`
      has `length(.) = 6` (scalars), `length(.u) = 3` (timesteps), and
      `voa[j, i]` = component `j` at time `i` — confirming my reasoning
      that the 2-arg indexing is unchanged.
- [ ] Full `Pkg.test()` local run — started under the v7 resolution. Will
      update this PR with the pass/fail result once the precompilation of
      the v7-DEV OrdinaryDiffEq + SciMLSensitivity + ModelingToolkit stack
      finishes locally.

## Relation to #292

Closes/supersedes #292. The `Project.toml` change here includes the
`DiffEqBase = "6, 7"` widening from #292 plus the companion source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)