### PR TITLE
Migrate CI to centralized SciML/.github reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,10 +10,14 @@ on:
       - master
     paths-ignore:
       - 'docs/**'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 jobs:
-  test:
-    runs-on: ubuntu-latest
+  tests:
+    name: "Tests"
     strategy:
+      fail-fast: false
       matrix:
         group:
           - All
@@ -21,28 +25,8 @@ jobs:
           - '1'
           - 'lts'
           - 'pre'
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.version }}
-      - uses: actions/cache@v5
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        env:
-          GROUP: ${{ matrix.group }}
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v6
-        with:
-          file: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+    with:
+      group: "${{ matrix.group }}"
+      julia-version: "${{ matrix.version }}"
+    secrets: "inherit"

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -1,28 +1,15 @@
 name: Documentation
-
 on:
   push:
     branches:
       - master
     tags: '*'
   pull_request:
-
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@latest
-        with:
-          version: '1'
-      - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
-      - name: Build and deploy
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key
-        run: julia --project=docs/ --code-coverage=user docs/make.jl
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v6
-        with:
-          file: lcov.info
+  docs:
+    name: "Documentation"
+    uses: "SciML/.github/.github/workflows/documentation.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -10,23 +10,15 @@ on:
       - master
     paths-ignore:
       - 'docs/**'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 jobs:
-  test:
+  downgrade:
+    name: "Downgrade"
     if: false
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      skip: "Pkg,TOML"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,5 +1,4 @@
-name: format-check
-
+name: FormatCheck
 on:
   push:
     branches:
@@ -8,15 +7,11 @@ on:
       - 'release-'
     tags: '*'
   pull_request:
-
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: "Runic"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -1,13 +1,10 @@
-name: Spell Check
-
+name: SpellCheck
 on: [pull_request]
-
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 jobs:
-  typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0 
+  spellcheck:
+    name: "SpellCheck"
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas

Normalizes this repo's CI to the centralized SciML/.github reusable workflows (all callers pinned `@v1`, `secrets: inherit`). Existing matrices and behavior are preserved; only the centralized wiring changes.

## Workflows converted
- **CI.yml** (Tests): now calls `tests.yml@v1`. Preserves the exact matrix `group: [All]` x `version: ['1','lts','pre']`, the `on: push/pull_request` to `master` with `paths-ignore: docs/**`. Coverage was collected in the original, so the default coverage behavior of the caller is retained.
- **Documentation.yml**: now calls `documentation.yml@v1`. Preserves `on: push (master + tags) / pull_request`. Original collected coverage.
- **Downgrade.yml**: now calls `downgrade.yml@v1` with `julia-version: "1.10"`, `skip: "Pkg,TOML"`. The original job was disabled (`if: false`); this is preserved (`if: false` kept on the caller job), so Downgrade remains disabled.
- **FormatCheck.yml** (Runic): now calls `runic.yml@v1`. The repo already ran Runic (fredrikekre/runic-action), so no reformatting was needed.
- **SpellCheck.yml**: now calls `spellcheck.yml@v1`. `typos` v1.34 runs clean locally (exit 0) against the existing `.typos.toml`, so no prose edits and no new typos config were needed.

## Workflows unchanged
- **TagBot.yml**: left as-is.

## Not added (absent in this repo)
- No downstream/IntegrationTest, benchmark (AirspeedVelocity), or QA (test/jet) workflows existed, so none were added.

## Runic formatting
- Not applied — the repo already enforced Runic, so it is already formatted.

## Dependabot / CompatHelper
- Removed the `crate-ci/typos` `ignore` block from the `github-actions` updates (standing policy: keep everything current, no per-dependency ignores).
- Preserved the existing `julia` block (`/`, `/docs`, `/test`; daily; `all-julia-packages: ["*"]`). Note `/test` has no `Project.toml` (test deps live in the main `Project.toml` `[extras]`/`[targets]`), but the entry is harmless and was left intact to avoid narrowing.
- No `CompatHelper.yml` existed in this repo, so there was nothing to remove.

## Typos findings
- None. `typos` v1.34.0 passes clean.

## Heads-up: branch protection
The job/check names change with this migration (e.g. the reusable workflows surface their own job names). **Branch-protection required-status-checks for `master` must be updated** to match the new check names, or merges may block on stale required checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)