### PR TITLE
Canonical CI cleanup: TagBot thin-caller + downgrade-caller cleanup

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -18,6 +18,5 @@ jobs:
     name: "Downgrade"
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:
-      julia-version: "1.10"
-      skip: "Pkg,TOML"
+      julia-version: "lts"
     secrets: "inherit"

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,15 +1,9 @@
-name: TagBot
+name: "TagBot"
 on:
   issue_comment:
-    types:
-      - created
+    types: [created]
   workflow_dispatch:
 jobs:
-  TagBot:
-    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: JuliaRegistries/TagBot@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}
+  tagbot:
+    uses: "SciML/.github/.github/workflows/tagbot.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Canonical CI cleanup applied per the SciML centralization campaign:

- **TagBot.yml**: replaced the inlined `JuliaRegistries/TagBot@v1` job (permissions + steps) with the canonical thin caller `SciML/.github/.github/workflows/tagbot.yml@v1` (`secrets: inherit`). This repo is a single package (no `lib/` subpackages), so no subpackage matrix is needed.
- **Downgrade.yml**: removed the hand-listed stdlib `skip: "Pkg,TOML"` input (both are Julia stdlibs; the centralized downgrade workflow now auto-populates the skip set from stdlibs + in-repo sublibs + the caller package), and set the downgrade Julia floor to `lts` (replacing the explicit `1.10`). The numeric `[compat] julia` floor was left untouched.

No monorepo subpackages, no `DowngradeSublibraries.yml`, and `.typos.toml` already exists, so no other changes were needed.

Ignore until reviewed by @ChrisRackauckas.