### PR TITLE
Canonicalize test units to @safetestset

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -39,6 +39,7 @@ PenaltyFunctions = "0.3"
 PreallocationTools = "0.4.34, 1.0"
 Random = "1"
 RecursiveArrayTools = "3.50, 4"
+SafeTestsets = "0.1, 1"
 SciMLBase = "2.153, 3"
 SciMLSensitivity = "7.80"
 SteadyStateDiffEq = "2"
@@ -65,6 +66,7 @@ OptimizationOptimJL = "36348300-93cb-4f02-beb5-3c3902f8871e"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLSensitivity = "1ed8b502-d754-442c-8d5d-10ac956f44a1"
 SteadyStateDiffEq = "9672c7b4-1e72-59bd-8a11-6ac3964bc41f"
 StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
@@ -73,4 +75,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Test", "ExplicitImports", "BlackBoxOptim", "DelayDiffEq", "ForwardDiff", "Logging", "NLopt", "Optim", "Optimization", "OptimizationBBO", "OptimizationNLopt", "OptimizationOptimJL", "OrdinaryDiffEq", "Pkg", "Random", "SciMLSensitivity", "StochasticDiffEq", "SteadyStateDiffEq", "Sundials", "Zygote"]
+test = ["Test", "ExplicitImports", "BlackBoxOptim", "DelayDiffEq", "ForwardDiff", "Logging", "NLopt", "Optim", "Optimization", "OptimizationBBO", "OptimizationNLopt", "OptimizationOptimJL", "OrdinaryDiffEq", "Pkg", "Random", "SafeTestsets", "SciMLSensitivity", "StochasticDiffEq", "SteadyStateDiffEq", "Sundials", "Zygote"]

--- a/test/out_of_place_odes.jl
+++ b/test/out_of_place_odes.jl
@@ -1,4 +1,4 @@
-using OrdinaryDiffEq, Test, SciMLSensitivity, Optimization, OptimizationOptimJL
+using OrdinaryDiffEq, Test, DiffEqParamEstim, SciMLSensitivity, Optimization, OptimizationOptimJL
 
 function LotkaVolterraTest_not_inplace(u, a, t)
     b, c, d = 1.0, 3.0, 1.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Pkg
 using DiffEqParamEstim, Test
+using SafeTestsets
 
 const GROUP = get(ENV, "GROUP", "All")
 
@@ -9,11 +10,12 @@ if GROUP == "QA"
     Pkg.instantiate()
     include("qa/qa.jl")
 else
-    @time @testset "Explicit Imports" begin
+    @time @safetestset "Explicit Imports" begin
         include("explicit_imports.jl")
     end
 
-    @time @testset "Tests on ODEs" begin
+    @time @safetestset "Tests on ODEs" begin
+        using DiffEqParamEstim
         include("tests_on_odes/test_problems.jl")
         include("tests_on_odes/l2loss_test.jl")
         include("tests_on_odes/optim_test.jl")
@@ -26,25 +28,25 @@ else
         #include("tests_on_odes/genetic_algorithm_test.jl") # Not updated to v0.6
     end
 
-    @time @testset "Multiple Shooting Objective" begin
+    @time @safetestset "Multiple Shooting Objective" begin
         include("multiple_shooting_objective_test.jl")
     end
-    @time @testset "Likelihood Loss" begin
+    @time @safetestset "Likelihood Loss" begin
         include("likelihood.jl")
     end
-    @time @testset "Out-of-place ODE Tests" begin
+    @time @safetestset "Out-of-place ODE Tests" begin
         include("out_of_place_odes.jl")
     end
-    @time @testset "Steady State Tests" begin
+    @time @safetestset "Steady State Tests" begin
         include("steady_state_tests.jl")
     end
-    @time @testset "DAE Tests" begin
+    @time @safetestset "DAE Tests" begin
         include("dae_tests.jl")
     end
-    @time @testset "DDE Tests" begin
+    @time @safetestset "DDE Tests" begin
         include("dde_tests.jl")
     end
-    @time @testset "Test on Monte" begin
+    @time @safetestset "Test on Monte" begin
         include("test_on_monte.jl")
     end
 end


### PR DESCRIPTION
Converts the independent top-level test units in `test/runtests.jl` from plain `@testset "X" begin ... end` to `@safetestset`, so each runs in its own module (test isolation + world-age safety), matching OrdinaryDiffEq's canonical structure.

**Converted units:** `Explicit Imports`, `Tests on ODEs`, `Multiple Shooting Objective`, `Likelihood Loss`, `Out-of-place ODE Tests`, `Steady State Tests`, `DAE Tests`, `DDE Tests`, `Test on Monte`.

**Self-containment handling:**
- `Tests on ODEs` is a single shared-state unit: `tests_on_odes/test_problems.jl` defines `prob1`/`prob2`/`prob3`/`t`/`data`/`sol` that the later includes in the same block consume, and several of those includes rely on `Optim`/etc. leaking between files within the block. It is therefore wrapped as **one** `@safetestset` whose body is the include chain (preserving the intra-block sharing exactly). Added `using DiffEqParamEstim` at the top of that body since the included files relied on it leaking from `Main`; SafeTestsets injects `using Test`.
- `out_of_place_odes.jl` used `build_loss_objective`/`L2Loss` but only had `using OrdinaryDiffEq, Test, ...` and relied on `DiffEqParamEstim` leaking from `Main` → added `DiffEqParamEstim` to its `using` line.
- The other standalone files already import `DiffEqParamEstim` plus their optimizer/solver deps, so they are self-contained as `@safetestset` modules.

**Deps:** added `SafeTestsets` to `[extras]`, `[targets].test`, and `[compat]` (`SafeTestsets = "0.1, 1"`), and `using SafeTestsets` in `runtests.jl`.

The `GROUP`/`QA` dispatch and all assertions are unchanged.

Verification: static — `Meta.parseall` of `runtests.jl` and `out_of_place_odes.jl` parse cleanly, and Runic formatting passes on all changed files. The suite pulls a heavy optimization/sensitivity stack (BlackBoxOptim, NLopt, Optim, Optimization, SciMLSensitivity, Sundials, StochasticDiffEq, Zygote) with long-running global optimizers, so it was not run locally; CI will verify.

This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)